### PR TITLE
French translation

### DIFF
--- a/localization/fr_FR.inc
+++ b/localization/fr_FR.inc
@@ -1,0 +1,44 @@
+﻿<?php
+$labels = array();
+$labels['caldavzap'] = 'Calendriers';
+$labels['todo'] = 'Tâches';
+$labels['reload'] = 'Rafraichir';
+
+$labels['cdz_standardview'] = 'Vue par défaut';
+$labels['cdz_weekstart'] = 'La semaine commence le';
+$labels['cdz_worktime'] = 'Heures de travail';
+$labels['cdz_weekendays'] = 'Jours du Weekend';
+
+$labels['cdz_month'] = 'Mois';
+$labels['cdz_multiWeek'] = 'Multisem.';
+$labels['cdz_agendaDay'] = 'Jour';
+$labels['cdz_agendaWeek'] = 'Semaine';
+
+$labels['cdz_day_0'] = 'Dimanche';
+$labels['cdz_day_1'] = 'Lundi';
+$labels['cdz_day_2'] = 'Mardi';
+$labels['cdz_day_3'] = 'Mercredi';
+$labels['cdz_day_4'] = 'Jeudi';
+$labels['cdz_day_5'] = 'Vendredi';
+$labels['cdz_day_6'] = 'Samedi';
+
+$labels['cdz_time_5']  = '05:00 am';
+$labels['cdz_time_6']  = '06:00 am';
+$labels['cdz_time_7']  = '07:00 am';
+$labels['cdz_time_8']  = '08:00 am';
+$labels['cdz_time_9']  = '09:00 am';
+$labels['cdz_time_10'] = '10:00 am';
+$labels['cdz_time_11'] = '11:00 am';
+$labels['cdz_time_12'] = '12:00 am';
+$labels['cdz_time_13'] = '01:00 pm';
+$labels['cdz_time_14'] = '02:00 pm';
+$labels['cdz_time_15'] = '03:00 pm';
+$labels['cdz_time_16'] = '04:00 pm';
+$labels['cdz_time_17'] = '05:00 pm';
+$labels['cdz_time_18'] = '06:00 pm';
+
+$labels['cdz_timezone'] = 'Fuseau horaire';
+$labels['cdz_tzsupport'] = 'Support du fuseau horaire';
+$labels['cdz_rewritetz'] = 'Réécriture du fuseau horaire';
+$labels['cdz_removetz'] = 'Supprimer fuseau horaire inconnu';
+?>


### PR DESCRIPTION
Hi,

This new file is french translation for the plugin.
It works fine with `Classic` an `Larry` skins.
With elastic skin, there isn't enough room for label, ellipsis is displayed.
`Calendars` is `Calendriers` in french, two letters more.
I'm not a web developper at all. I have tried to read the css but it's a complete mystery for me. I don't know how to increase the `button` size to make it be displayed correctly.
